### PR TITLE
(feature and fix)  Add [Image]  type of star icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,9 @@ And then set up [react-native-vector-icons](https://github.com/oblador/react-nat
 | Prop | Type | Description | Required | Default |
 |---|---|---|---|---|
 |**`disabled`**|`bool`|Sets the interactivity of the star buttons. |`No`|`false`|
-|**`emptyStar`**|`string`|The name of the icon to represent an empty star. Refer to [react-native-vector-icons](https://github.com/oblador/react-native-vector-icons). |`No`|`star-o`|
-|**`fullStar`**|`string`|The name of the icon to represent a full star. Refer to [react-native-vector-icons](https://github.com/oblador/react-native-vector-icons). |`No`|`star`|
-|**`halfStar`**|`string`|The name of the icon to represent an half star. Refer to [react-native-vector-icons](https://github.com/oblador/react-native-vector-icons).  |`No`|`star-half-o`|
+|**`emptyStar`**|`string or image object`|The name of the icon to represent an empty star. Refer to [react-native-vector-icons](https://github.com/oblador/react-native-vector-icons). Also can be a image object, both {uri:xxx.xxx} and require('xx/xx/xx.xxx').|`No`|`star-o`|
+|**`fullStar`**|`string or image object`|The name of the icon to represent a full star. Refer to [react-native-vector-icons](https://github.com/oblador/react-native-vector-icons). Also can be a image object, both {uri:xxx.xxx} and require('xx/xx/xx.xxx').|`No`|`star`|
+|**`halfStar`**|`string or image object`|The name of the icon to represent an half star. Refer to [react-native-vector-icons](https://github.com/oblador/react-native-vector-icons).  Also can be a image object, both {uri:xxx.xxx} and require('xx/xx/xx.xxx').|`No`|`star-half-o`|
 |**`iconSet`**|`string`|The name of the icon set the star image belongs to. Refer to [react-native-vector-icons](https://github.com/oblador/react-native-vector-icons).  |`No`|`FontAwesome`|
 |**`maxStars`**|`number`|The maximum number of stars possible. |`No`|`5`|
 |**`rating`**|`number`|The current rating to show.  |`No`|`0`|

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "author": "Derrick Chie <djchie.dev@gmail.com> (https://github.com/djchie)",
   "license": "ISC",
   "dependencies": {
+    "prop-types": "^15.5.10",
     "react-native-button": "^1.6.0",
     "react-native-vector-icons": "^2.0.3"
   },

--- a/star-button.js
+++ b/star-button.js
@@ -71,6 +71,7 @@ StarButton.propTypes = {
   starIconName: PropTypes.oneOfType([
       PropTypes.string,
       PropTypes.object,
+      PropTypes.number,
   ]),
   starColor: PropTypes.string,
   starStyle: ViewPropTypes.style,

--- a/star-button.js
+++ b/star-button.js
@@ -1,9 +1,8 @@
 // React and react native imports
 import React, {
-  Component,
-  PropTypes,
+  Component
 } from 'react';
-import { View } from 'react-native';
+import { View, ViewPropTypes, Image } from 'react-native';
 
 // Third party imports
 import Button from 'react-native-button';
@@ -15,6 +14,7 @@ import IoniconsIcons from 'react-native-vector-icons/Ionicons';
 import MaterialIconsIcons from 'react-native-vector-icons/MaterialIcons';
 import OcticonsIcons from 'react-native-vector-icons/Octicons';
 import ZocialIcons from 'react-native-vector-icons/Zocial';
+import PropTypes from 'prop-types';
 
 const iconSets = {
   Entypo: EntypoIcons,
@@ -40,27 +40,25 @@ class StarButton extends Component {
   }
 
   render() {
-    const Icon = iconSets[this.props.iconSet];
-
-    return (
-      <Button
-        activeOpacity={0.20}
-        disabled={this.props.disabled}
-        onPress={this.onButtonPress}
-        containerStyle={this.props.buttonStyle}
-        style={{
-          height: this.props.starSize,
-          width: this.props.starSize,
-        }}
-      >
-        <Icon
-          name={this.props.starIconName}
-          size={this.props.starSize}
-          color={this.props.starColor}
-          style={this.props.starStyle}
-        />
-      </Button>
-    );
+      const Icon = iconSets[this.props.iconSet];
+      const { starSize,starIconName,starColor,starStyle,buttonStyle,disabled } = this.props;
+      return (
+          <Button
+              activeOpacity={0.20}
+              disabled={disabled}
+              onPress={this.onButtonPress}
+              containerStyle={buttonStyle}
+              style={{
+                  height: starSize,
+                  width: starSize,
+              }}
+          >
+              { typeof starIconName ==='string'?
+                  <Icon name={starIconName} size={starSize} color={starColor} style={starStyle}/> :
+                  <Image source={starIconName} style={[{width:starSize,height:starSize,resizeMode:'contain'},starStyle]} />
+              }
+          </Button>
+      );
   }
 }
 
@@ -70,10 +68,13 @@ StarButton.propTypes = {
   onStarButtonPress: PropTypes.func,
   iconSet: PropTypes.string,
   starSize: PropTypes.number,
-  starIconName: PropTypes.string,
+  starIconName: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.object,
+  ]),
   starColor: PropTypes.string,
-  starStyle: View.propTypes.style,
-  buttonStyle: View.propTypes.style,
+  starStyle: ViewPropTypes.style,
+  buttonStyle: ViewPropTypes.style,
 };
 
 export default StarButton;

--- a/star-rating.js
+++ b/star-rating.js
@@ -1,14 +1,13 @@
 // React and react native imports
 import {
   StyleSheet,
-  View,
+  View,ViewPropTypes,
 } from 'react-native';
 
 import React, {
   Component,
-  PropTypes,
 } from 'react';
-
+import PropTypes from 'prop-types';
 // Local file imports
 import StarButton from './star-button';
 
@@ -84,9 +83,18 @@ class StarRating extends Component {
 
 StarRating.propTypes = {
   disabled: PropTypes.bool,
-  emptyStar: PropTypes.string,
-  fullStar: PropTypes.string,
-  halfStar: PropTypes.string,
+  emptyStar: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.object,
+  ]),
+  fullStar: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.object,
+  ]),
+  halfStar: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.object,
+  ]),
   iconSet: PropTypes.string,
   maxStars: PropTypes.number,
   rating: PropTypes.number,
@@ -94,8 +102,8 @@ StarRating.propTypes = {
   starColor: PropTypes.string,
   emptyStarColor: PropTypes.string,
   starSize: PropTypes.number,
-  starStyle: View.propTypes.style,
-  buttonStyle: View.propTypes.style,
+  starStyle: ViewPropTypes.style,
+  buttonStyle: ViewPropTypes.style,
 };
 
 StarRating.defaultProps = {

--- a/star-rating.js
+++ b/star-rating.js
@@ -86,14 +86,17 @@ StarRating.propTypes = {
   emptyStar: PropTypes.oneOfType([
       PropTypes.string,
       PropTypes.object,
+      PropTypes.number,
   ]),
   fullStar: PropTypes.oneOfType([
       PropTypes.string,
       PropTypes.object,
+      PropTypes.number,
   ]),
   halfStar: PropTypes.oneOfType([
       PropTypes.string,
       PropTypes.object,
+      PropTypes.number,
   ]),
   iconSet: PropTypes.string,
   maxStars: PropTypes.number,


### PR DESCRIPTION
- Now you can pass an image object to [emptyStar | fullStar | halfStar]
- Fix Proptypes warning when react-native version above 0.44

e.g.
```
  <StarRating
          emptyStar={require('../../images/shxq_xl1.png')}
          fullStar={require('../../images/shxq_xl.png')}
      />
```