### PR TITLE
Current implementation doesn't allow Image object to be the star button.

### DIFF
--- a/star-button.js
+++ b/star-button.js
@@ -70,20 +70,20 @@ class StarButton extends Component {
     } = this.props;
 
     const Icon = iconSets[iconSet];
-
-    return (
-      <Button
-        activeOpacity={0.20}
-        disabled={disabled}
-        onPress={this.onButtonPress}
-        containerStyle={buttonStyle}
-      >
-        { typeof starIconName ==='string'?
-          <Icon name={starIconName} size={starSize} color={starColor} style={starStyle}/> :
-          <Image source={starIconName} style={[{width:starSize,height:starSize,resizeMode:'contain'},starStyle]} />
-        }
-      </Button>
-    );
+    if (typeof starIconName === 'string') {
+      return (
+        <Button
+          activeOpacity={0.20}
+          disabled={disabled}
+          onPress={this.onButtonPress}
+          containerStyle={buttonStyle}
+        >
+          <Icon name={starIconName} size={starSize} color={starColor} style={starStyle}/>
+        </Button>
+      );
+    } else {
+      return starIconName;
+    }
   }
 
 }

--- a/star-rating.js
+++ b/star-rating.js
@@ -14,8 +14,7 @@ import StarButton from './star-button';
 
 const styles = StyleSheet.create({
   starRatingContainer: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
+    flexDirection: 'row'
   },
 });
 


### PR DESCRIPTION
The documentation said that the star object can be an image object, but the implementation doesn't reflect that. I change the implementation to this one and it's working perfectly with the image object. Example:
```
<StarRating disabled={true}
            maxStars={5}
            rating={item.rating}
            emptyStar={<Image source={require('./images/star-empty.png')} style={styles.ratingStar}/>}
            fullStar={<Image source={require('./images/star-full.png')} style={styles.ratingStar}/>}
            halfStar={<Image source={require('./images/star-half.png')} style={styles.ratingStar}/>}
          />
```