### PR TITLE
(feat) Add icoMoonJson prop to use custom iconset with icomoon configuration json

### DIFF
--- a/star-button.js
+++ b/star-button.js
@@ -8,6 +8,7 @@ import {
 } from 'react-native';
 import PropTypes from 'prop-types';
 import update from 'react-addons-update';
+import { createIconSetFromIcoMoon } from 'react-native-vector-icons';
 
 // Third party imports
 import Button from 'react-native-button';
@@ -61,7 +62,6 @@ class StarButton extends Component {
 
   renderIcon() {
     const {
-      iconSet,
       starIconName,
       starSize,
       starColor,
@@ -69,7 +69,7 @@ class StarButton extends Component {
       reversed,
     } = this.props;
 
-    const Icon = iconSets[iconSet];
+    const Icon = this.iconSetFromProps();
     let iconElement;
 
     // To check if we need to reverse the star icon
@@ -115,6 +115,19 @@ class StarButton extends Component {
     return iconElement;
   }
 
+  iconSetFromProps() {
+    const {
+      iconSet,
+      icoMoonJson
+    } = this.props;
+    if (icoMoonJson) {
+      return createIconSetFromIcoMoon(icoMoonJson);
+
+    } else {
+      return iconSets[iconSet];
+    }
+  }
+
   render() {
     const {
       disabled,
@@ -140,6 +153,7 @@ StarButton.propTypes = {
   rating: PropTypes.number.isRequired,
   onStarButtonPress: PropTypes.func.isRequired,
   iconSet: PropTypes.string.isRequired,
+  icoMoonJson: PropTypes.string,
   starSize: PropTypes.number.isRequired,
   starIconName: PropTypes.oneOfType([
     PropTypes.string,

--- a/star-rating.js
+++ b/star-rating.js
@@ -38,6 +38,7 @@ class StarRating extends Component {
       starColor,
       disabled,
       iconSet,
+      icoMoonJson,
       starSize,
       starStyle,
       buttonStyle,
@@ -74,6 +75,7 @@ class StarRating extends Component {
           rating={i + 1}
           onStarButtonPress={this.onStarButtonPress}
           iconSet={iconSet}
+          icoMoonJson={icoMoonJson}
           starSize={starSize}
           starIconName={starIconName}
           starColor={finalStarColor}
@@ -114,6 +116,7 @@ StarRating.propTypes = {
     PropTypes.number,
   ]),
   iconSet: PropTypes.string,
+  icoMoonJson: PropTypes.object,
   maxStars: PropTypes.number,
   rating: PropTypes.number,
   selectedStar: PropTypes.func,


### PR DESCRIPTION
This PR adds the prop `icoMoonJson` to the components `StarButton` and `StarRating` so that the user can pass a IcoMoon son configuration to use a custom icon set.

usage of the prop is illustrated in the following example:

```
import StarRating from 'react-native-star-rating';
import icoMoonJson from './my-icomoon-project.json';

class CustomIconSetExample extends Component {

  constructor(props) {
    super(props);
    this.state = {
      starCount: 2.5
    };
  }

  onStarRatingPress(rating) {
    this.setState({
      starCount: rating
    });
  }

  render() {
    return (
      <StarRating
        maxStars={5}
        icoMoonJson={icoMoonJson}
        emptyStar={'my-custom-empty-star'}
        fullStar={'my-custom-full-star'}
        rating={this.state.starCount}
        selectedStar={(rating) => this.onStarRatingPress(rating)}
      />
    );
  }
}

export default CustomIconSetExample
```