### PR TITLE
Fix crash when setting `StarStyle` using a StyleSheet object

### DIFF
--- a/star-button.js
+++ b/star-button.js
@@ -4,6 +4,7 @@ import React, {
 } from 'react';
 import {
   ViewPropTypes,
+  StyleSheet,
   Image,
 } from 'react-native';
 import PropTypes from 'prop-types';
@@ -73,7 +74,7 @@ class StarButton extends Component {
     let iconElement;
 
     // To check if we need to reverse the star icon
-    const newStarStyle = update(starStyle, {
+    const newStarStyle = update(StyleSheet.flatten(starStyle), {
       transform: {
         $set: [
           {


### PR DESCRIPTION
should fix #56 

The problem comes from the fact that RN StyleSheet object are number references and not the style object directly. But we can retrieve the style object using the `StyleSheet.flatten()` function.

In 1.0.8, the code was modified to support reversing the star icon and to do that it was updating the `starStyle` object by adding a `transform` attribute. So when passing a StyleSheet reference, it tries to update an object that was in fact a constant number and it crashes with the error:

`TypeError: Attempted to assign to readonly property` or `Cannot create property 'transform' on number 'XXX'`