### PR TITLE
Fix misalignment issues for starts

### DIFF
--- a/StarRating.js
+++ b/StarRating.js
@@ -93,7 +93,7 @@ class StarRating extends Component {
 
     const newContainerStyle = {
       flexDirection: reversed ? 'row-reverse' : 'row',
-      justifyContent: 'space-between',
+      justifyContent: 'flex-start',
       ...containerStyle,
     };
 


### PR DESCRIPTION
Stars are misaligned when display on a view. This is due to the fact that the default justifycontent is space-between rather than flex-start