### PR TITLE
Added activeOpacity prop to the component

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ npm install react-native-star-rating --save
 
 |Prop|Type|Description|Required|Default|
 |---|---|---|---|---|
-|**`activeOpacity`**|`number`|Number between 0 a 1 to determine the opacity of the button.|`No`|*`0.2`*|
+|**`activeOpacity`**|`number`|Number between 0 a 1 to determine the opacity of the button.|`No`|`0.2`|
 |**`buttonStyle`**|`ViewPropTypes.style`|Style of the button containing the star.|`No`|*`{}`*|
 |**`containerStyle`**|`ViewPropTypes.style`|Style of the element containing the star rating component.|`No`|*`{}`*|
 |**`disabled`**|`bool`|Sets the interactivity of the star buttons. |`No`|`false`|

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ npm install react-native-star-rating --save
 
 |Prop|Type|Description|Required|Default|
 |---|---|---|---|---|
+|**`activeOpacity`**|`number`|Number between 0 a 1 to determine the opacity of the button.|`No`|*`0.2`*|
 |**`buttonStyle`**|`ViewPropTypes.style`|Style of the button containing the star.|`No`|*`{}`*|
 |**`containerStyle`**|`ViewPropTypes.style`|Style of the element containing the star rating component.|`No`|*`{}`*|
 |**`disabled`**|`bool`|Sets the interactivity of the star buttons. |`No`|`false`|

--- a/StarButton.js
+++ b/StarButton.js
@@ -46,6 +46,7 @@ const propTypes = {
     PropTypes.number,
   ]).isRequired,
   starSize: PropTypes.number.isRequired,
+  activeOpacity: PropTypes.number.isRequired,
   starStyle: ViewPropTypes.style,
 };
 
@@ -137,11 +138,12 @@ class StarButton extends Component {
     const {
       disabled,
       buttonStyle,
+      activeOpacity
     } = this.props;
 
     return (
       <Button
-        activeOpacity={0.20}
+        activeOpacity={activeOpacity}
         disabled={disabled}
         containerStyle={buttonStyle}
         onPress={this.onButtonPress}

--- a/StarRating.js
+++ b/StarRating.js
@@ -7,6 +7,7 @@ import PropTypes from 'prop-types';
 import StarButton from './StarButton';
 
 const propTypes = {
+  activeOpacity: PropTypes.number,
   buttonStyle: ViewPropTypes.style,
   containerStyle: ViewPropTypes.style,
   disabled: PropTypes.bool,
@@ -39,6 +40,7 @@ const propTypes = {
 };
 
 const defaultProps = {
+  activeOpacity: 0.2,
   buttonStyle: {},
   containerStyle: {},
   disabled: false,
@@ -73,6 +75,7 @@ class StarRating extends Component {
 
   render() {
     const {
+      activeOpacity,
       buttonStyle,
       containerStyle,
       disabled,
@@ -119,7 +122,7 @@ class StarRating extends Component {
 
       const starButtonElement = (
         <StarButton
-          activeOpacity={0.20}
+          activeOpacity={activeOpacity}
           buttonStyle={buttonStyle}
           disabled={disabled}
           halfStarEnabled={halfStarEnabled}


### PR DESCRIPTION
I didn't like the fact that once you press the star it flashes the opacity, so I added the ability to change it wether you want it or not. By default is set to 0.2 and it's optional. Updated the README too.