### PR TITLE
Call StyleSheet.flatten() on containerStyle

### DIFF
--- a/StarRating.js
+++ b/StarRating.js
@@ -1,6 +1,6 @@
 // React and react native imports
 import React, { Component } from 'react';
-import { View, ViewPropTypes } from 'react-native';
+import { View, ViewPropTypes, StyleSheet } from 'react-native';
 import PropTypes from 'prop-types';
 
 // Local file imports
@@ -94,7 +94,7 @@ class StarRating extends Component {
     const newContainerStyle = {
       flexDirection: reversed ? 'row-reverse' : 'row',
       justifyContent: 'space-between',
-      ...containerStyle,
+      ...StyleSheet.flatten(containerStyle),
     };
 
     // Round rating down to nearest .5 star


### PR DESCRIPTION
Relevant SO question: https://stackoverflow.com/questions/37020404/error-when-creating-new-object-from-existing-one-using-in-this-environmen

When passing in a property of a `StyleSheet` object as `containerStyle` like below, currently an error is thrown because `StyleSheet` properties are not plain JS objects so you can't use `...` on them. It's necessary to call `StyleSheet.flatten` first.

```jsx
<StarRating containerStyle={styles.foo} />

const styles = StyleSheet.create({
    foo: {justifyContent: 'flex-start'}
})

// Unhandled JS Exception: In this environment the sources for assign MUST be an object.This error is a performance optimization and not spec compliant.
```