### PR TITLE
Disabled touch events when disabled

### DIFF
--- a/StarRating.js
+++ b/StarRating.js
@@ -140,7 +140,7 @@ class StarRating extends Component {
     }
 
     return (
-      <View style={newContainerStyle}>
+      <View style={newContainerStyle} pointerEvents={disabled ? 'none' : 'auto'}>
         {starButtons}
       </View>
     );


### PR DESCRIPTION
### Motivation
Say if you have a button that has a star rating in it. The star rating is disabled.
If you want to click on the button and you press on the star instead, no touch event for the parent button will fire.

Snack example: https://snack.expo.io/HJW0ejsL7

### Solution
Use the `pointerEvents` property to allow ignore touches when the star rating is disabled. That way the parent button would be able to receive touch events.
