### PR TITLE
Enable choosing star color for image-based stars

### DIFF
--- a/StarButton.js
+++ b/StarButton.js
@@ -128,6 +128,7 @@ class StarButton extends Component {
         width: starSize,
         height: starSize,
         resizeMode: 'contain',
+        tintColor: starColor,
       };
 
       const iconStyles = [


### PR DESCRIPTION
Fixes bug where star color props would not be applied when using raster images (rather than icon) for star asset