### PR TITLE
"react-native-vector-icons": "^6.1.0"

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "prop-types": "^15.5.10",
     "react-native-animatable": "^1.2.4",
     "react-native-button": "^2.3.0",
-    "react-native-vector-icons": "^4.5.0"
+    "react-native-vector-icons": "^6.1.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
gradle sync failed due to old gradle settings in the `react-native-vector-icons` package