### PR TITLE
Pass star color to star's image prop

### DIFF
--- a/StarButton.js
+++ b/StarButton.js
@@ -128,6 +128,7 @@ class StarButton extends Component {
         width: starSize,
         height: starSize,
         resizeMode: 'contain',
+        tintColor: starColor,
       };
 
       const iconStyles = [


### PR DESCRIPTION
The star color props were previously ignored if an image was being used instead of an icon for the star. I updated the style object for the image component to take into account the star color.